### PR TITLE
QR コードを正常に出力できていない問題を修正

### DIFF
--- a/main.js
+++ b/main.js
@@ -97,6 +97,11 @@ function downloadVCardRAW() {
     element.click();
 }
 
+const toUtf8 = str =>
+    Array.from(new TextEncoder().encode(str)).map(c =>
+        String.fromCharCode(c)
+    ).join('');
+
 function generateQR() {
     var str = ''
     data = generateVCard()
@@ -106,7 +111,7 @@ function generateQR() {
 
     var qr = new QRious({
         element: document.getElementById('canvas_qr'),
-        value: str
+        value: toUtf8(str),
     })
     qr.background = '#FFF'; //背景色
     qr.backgroundAlpha = 1.0; // 背景の透過率


### PR DESCRIPTION
QR コードとして出力する文字列を UTF-8 でエンコードしなおすことで文字化けを防ぎます。
JavaScript が文字（string）を UTF-16 で扱っていることが原因なのか、qrious との相性が悪いだけなのかはわかりません。