### PR TITLE
vCard ファイルの改行文字を修正

### DIFF
--- a/main.js
+++ b/main.js
@@ -87,7 +87,7 @@ function downloadVCardRAW() {
     var str = ''
     data = generateVCard()
     for (i=0;i<data.length;i++){
-        str = str + data[i] + "\n"
+        str = str + data[i] + "\r\n"
     }
     const blob = new Blob([str],{type:"text/x-vcard"});
     let element = document.createElement('a');


### PR DESCRIPTION
改行シークエンスは LF ではなく CRLF であるようです

修正前では `file`(1) に掛けると文句を言われるようでした。

```console
% file vcard.vcf 
vcard.vcf: vCard visiting card, version 3.0, 2nd line does not start with VERSION:, lines not separated by CRLF
```